### PR TITLE
Fix error with union between bitset! and string!

### DIFF
--- a/parse/JSON.red
+++ b/parse/JSON.red
@@ -11,7 +11,7 @@ json: context [
 	exponent:	 charset "eE"
 	sign:		 charset "+-"
 	digit-nz:	 charset "123456789"
-	digit:		 union digit-nz "0"
+	digit:		 union digit-nz charset "0"
 	hexa:		 union digit charset "ABCDEFabcdef"
 	blank:		 charset " ^(09)^(0A)^(0D)"
 	ws:		 [any blank]


### PR DESCRIPTION
Fix the following error:
 *** Script Error: expected bitset! not string!
 *** Where: union
 *** Stack: do-file context